### PR TITLE
Added error message notification feature for when the batch status is…

### DIFF
--- a/force/sobjects.go
+++ b/force/sobjects.go
@@ -76,6 +76,7 @@ type CreateBatchResponse struct {
 	State                   string `json:"state"`
 	SystemModstamp          string `json:"systemModstamp"`
 	TotalProcessingTime     int    `json:"totalProcessingTime"`
+	StateMessage			string `json:"stateMessage"`
 }
 
 type bulkMode int
@@ -268,7 +269,7 @@ func (forceApi *ForceApi) bulkModifySObjects(b bulkMode, table string, in []SObj
 		}
 
 		if res.State == "Failed" {
-			return nil, errors.New("Failed import")
+			return nil, errors.New(res.StateMessage)
 		}
 	}
 


### PR DESCRIPTION
Bulk Updateする時にジョブ登録しして、そのジョブに対してバッチを登録（1件のみ）して、バッチのステータスをチェックしていますが。
バッチのステータスが"Failed"の場合、そのFailedの原因を通知するためにエラーメッセージを返却できるようにしました。

下記のドキュメント（BatchInfo）の `stateMessage` を利用しました
https://developer.salesforce.com/docs/atlas.ja-jp.202.0.api_asynch.meta/api_asynch/asynch_api_reference_batchinfo.htm
